### PR TITLE
Departures filterbaar op destination van station widget

### DIFF
--- a/src/smartMirrorProject/theMirror/static/theMirror/style.css
+++ b/src/smartMirrorProject/theMirror/static/theMirror/style.css
@@ -106,14 +106,11 @@ footer {
 /*=======================================================================*/
 .travel-widget {
     max-height: 200px;
-    /* Adjust the height based on your layout */
     overflow-y: auto;
     /* Allow vertical scrolling */
     font-size: 12px;
-    /* Smaller text for more content */
     display: flex;
     flex-direction: column;
-    /* Ensure header and table are stacked vertically */
 }
 
 .travel-widget h3 {

--- a/src/smartMirrorProject/theMirror/templates/theMirror/widgets/travel2.html
+++ b/src/smartMirrorProject/theMirror/templates/theMirror/widgets/travel2.html
@@ -1,0 +1,37 @@
+{% if data %}
+<div class="travel-widget">
+    <!-- Header Above the Table -->
+    <h3>Departures</h3>
+
+    <div class="station-info">
+        <p> {{ widgets.Travel2.station }} </p>
+    </div>
+
+    <table>
+        <thead>
+            <tr>
+                <th>Destination</th>
+                <th>Train Type</th>
+                <th>Planned Time</th>
+                <th>Actual Time</th>
+                <th>Delay</th>
+                <th>Track</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for departure in data %}
+            <tr>
+                <td>{{ departure.destination }}</td>
+                <td>{{ departure.trainCategory }}</td>
+                <td>{{ departure.plannedDateTime }}</td>
+                <td>{{ departure.actualDateTime }}</td>
+                <td>{{ departure.delay }}</td>
+                <td>{{ departure.plannedTrack|default:"N/A" }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% else %}
+<p>No departure data available.</p>
+{% endif %}


### PR DESCRIPTION
Departures tabel toegevoegd, filterbaar op destination. Inclusief delay & spoornummer. CSS van andere travel widget overgenomen.

Heb nog wel wat feedback nodig op bijv. het type (alleen travel pakte hij niet, beide widgets waren opeens leeg qua data, travel2 deed het wel).
Heb de HTML voor nu travel2.html genoemd, verbeteringen hiervoor zijn altijd welkom. 
Hij laat het station bovenaan de widget zien, helaas kon ik dit niet rechtstreeks uit de API halen en meegeven in data. Als de gebruiker het wilt aanpassen, kan hij/zij/x het target station kiezen, de destinations evt filteren, en dan moet hij/zij/x zelf de locatie uittypen. 
